### PR TITLE
fix: enable mps device selection in prediction and training widgets

### DIFF
--- a/panseg/viewer_napari/widgets/prediction.py
+++ b/panseg/viewer_napari/widgets/prediction.py
@@ -32,8 +32,7 @@ class Prediction_Widgets:
         self.additional_layer_container = widget_layer_select[-1]
         # Constants
         self.ALL_CUDA_DEVICES = [f"cuda:{i}" for i in range(torch.cuda.device_count())]
-        # self.MPS = ["mps"] if torch.backends.mps.is_available() else []
-        self.MPS = []  # MPS does lack some necessary ops #385
+        self.MPS = ["mps"] if torch.backends.mps.is_available() else []
         self.ALL_DEVICES = self.ALL_CUDA_DEVICES + self.MPS + ["cpu"]
 
         self.BIOIMAGEIO_FILTER = [("PanSeg Only", True), ("All", False)]

--- a/panseg/viewer_napari/widgets/training.py
+++ b/panseg/viewer_napari/widgets/training.py
@@ -27,8 +27,7 @@ class Training_Tab:
 
         # Constants
         self.ALL_CUDA_DEVICES = [f"cuda:{i}" for i in range(torch.cuda.device_count())]
-        # self.MPS = ["mps"] if torch.backends.mps.is_available() else []
-        self.MPS = []  # MPS does lack some necessary ops #385
+        self.MPS = ["mps"] if torch.backends.mps.is_available() else []
         self.ALL_DEVICES = self.ALL_CUDA_DEVICES + self.MPS + ["cpu"]
         self.CUSTOM = "Custom"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ extend-exclude = ["tests/**", "panseg/**", "examples/**", "*.yml", "*.yaml"]
 extend-select = ["I"]
 
 [tool.coverage.run]
+source = ["panseg/"]
+omit = ["/tmp/*"]
+
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration
 exclude_also = [
@@ -77,8 +80,6 @@ exclude_also = [
   # Don't complain about abstract methods, they aren't run:
   "@(abc\\.)?abstractmethod",
 ]
-source = ["panseg/"]
-omit = ["/tmp/*"]
 
 [tool.bumpversion]
 current_version = "2.1.1"

--- a/tests/functionals/prediction/test_mps_prediction.py
+++ b/tests/functionals/prediction/test_mps_prediction.py
@@ -1,0 +1,54 @@
+"""End-to-end UNet prediction on Apple silicon MPS devices.
+
+Only runs where torch.backends.mps.is_available() is True; guards the device
+plumbing (model placement + OOM probe) that previously broke prediction on
+Apple silicon, see https://github.com/kreshuklab/panseg/issues/385 and #552.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from panseg.functionals.prediction.prediction import unet_prediction
+from panseg.functionals.training.model import UNet3D
+
+IS_MPS_AVAILABLE = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+
+
+@pytest.mark.skipif(
+    not IS_MPS_AVAILABLE, reason="Requires an Apple silicon GPU (MPS) device."
+)
+def test_unet_prediction_with_mps_device(tmp_path):
+    model = UNet3D(in_channels=1, out_channels=1, final_sigmoid=True, f_maps=[8, 16])
+    weights_path = tmp_path / "best_checkpoint.pytorch"
+    torch.save(model.state_dict(), weights_path)
+
+    config_path = tmp_path / "config_train.yml"
+    config_path.write_text(
+        """model:
+  name: UNet3D
+  in_channels: 1
+  out_channels: 1
+  final_sigmoid: true
+  layer_order: gcr
+  f_maps: [8, 16]
+  num_groups: 4
+"""
+    )
+
+    raw = np.random.rand(16, 24, 32).astype("float32")  # ZYX
+    pmap = unet_prediction(
+        raw=raw,
+        input_layout="ZYX",
+        model_name=None,
+        model_id=None,
+        patch=(8, 8, 8),
+        patch_halo=(0, 0, 0),
+        config_path=config_path,
+        model_weights_path=weights_path,
+        device="mps",
+        disable_tqdm=True,
+    )
+
+    assert pmap.shape[-3:] == raw.shape
+    assert np.all(np.isfinite(pmap))

--- a/tests/functionals/prediction/test_mps_prediction.py
+++ b/tests/functionals/prediction/test_mps_prediction.py
@@ -36,13 +36,13 @@ def test_unet_prediction_with_mps_device(tmp_path):
 """
     )
 
-    raw = np.random.rand(16, 24, 32).astype("float32")  # ZYX
+    raw = np.random.rand(16, 64, 64).astype("float32")  # ZYX
     pmap = unet_prediction(
         raw=raw,
         input_layout="ZYX",
         model_name=None,
         model_id=None,
-        patch=(8, 8, 8),
+        patch=None,
         patch_halo=(0, 0, 0),
         config_path=config_path,
         model_weights_path=weights_path,

--- a/tests/widgets/test_prediction.py
+++ b/tests/widgets/test_prediction.py
@@ -298,3 +298,19 @@ def test_on_widget_unet_prediction_panseg_filter_change(segmentation_tab, mocker
 def test_on_any_metadata_changed(segmentation_tab):
     segmentation_tab.prediction_widgets.model_filters[0].value = "2D"
     segmentation_tab.prediction_widgets.model_filters[0].value = "3D"
+
+
+def test_device_choices_include_mps_when_available(mocker):
+    mocker.patch("torch.backends.mps.is_available", return_value=True)
+
+    tab = Segmentation_Tab()
+
+    assert "mps" in tab.prediction_widgets.ALL_DEVICES
+
+
+def test_device_choices_exclude_mps_when_unavailable(mocker):
+    mocker.patch("torch.backends.mps.is_available", return_value=False)
+
+    tab = Segmentation_Tab()
+
+    assert "mps" not in tab.prediction_widgets.ALL_DEVICES

--- a/tests/widgets/test_training_widget.py
+++ b/tests/widgets/test_training_widget.py
@@ -829,3 +829,19 @@ def test_on_segmentation_change(training_tab, mocker, napari_segmentation):
     m_update_dimensionality = mocker.patch.object(training_tab, "update_dimensionality")
     training_tab._on_image_change(napari_segmentation)
     m_update_dimensionality.assert_called_once()
+
+
+def test_device_choices_include_mps_when_available(mocker):
+    mocker.patch("torch.backends.mps.is_available", return_value=True)
+
+    tab = Training_Tab(None)
+
+    assert "mps" in tab.ALL_DEVICES
+
+
+def test_device_choices_exclude_mps_when_unavailable(mocker):
+    mocker.patch("torch.backends.mps.is_available", return_value=False)
+
+    tab = Training_Tab(None)
+
+    assert "mps" not in tab.ALL_DEVICES


### PR DESCRIPTION
Fixes #552

## What this does

The Prediction and Training widget tabs hard-coded `MPS = []` (with a note referencing the original missing-ops report #385), so Apple silicon GPUs were never offered as a device even when PyTorch MPS support is available. Both tabs now include `mps` in their device choices whenever `torch.backends.mps.is_available()` returns True:

```python
self.MPS = ["mps"] if torch.backends.mps.is_available() else []
```

## Tests

- New hermetic widget tests (mocking `torch.backends.mps.is_available`) assert that `mps` appears/disappears from the device choices in both tabs — platform-independent, pass on Linux/Windows/macOS.
- New end-to-end test `tests/functionals/prediction/test_mps_prediction.py` runs a full safari-mode `unet_prediction(device="mps")` with a small UNet3D (tmp_path weights + yaml config). It is skipped unless MPS is available, so it exercises the real device placement and OOM-probe path on the macOS CI runner (`test_matrix.yml`).

## QA steps (macOS)

1. Open PanSeg's Prediction tab → `mps` appears in the Device dropdown alongside cpu/cuda entries.
2. Run a prediction with Device = mps on an Apple silicon machine; it completes without errors.