### PR TITLE
fix: verify auto-determined patch shape fits on device before prediction

### DIFF
--- a/panseg/functionals/prediction/prediction.py
+++ b/panseg/functionals/prediction/prediction.py
@@ -22,8 +22,7 @@ from panseg.functionals.dataprocessing.dataprocessing import (
 from panseg.functionals.prediction.utils.array_dataset import ArrayDataset
 from panseg.functionals.prediction.utils.array_predictor import ArrayPredictor
 from panseg.functionals.prediction.utils.size_finder import (
-    find_a_max_patch_shape,
-    find_patch_and_halo_shapes,
+    find_feasible_patch_and_halo_shapes,
 )
 from panseg.functionals.prediction.utils.slice_builder import SliceBuilder
 from panseg.functionals.prediction.utils.utils import get_stride_shape
@@ -244,9 +243,6 @@ def unet_prediction(
             patch_halo = (0, 0, 0)
 
     if patch is None:
-        maximum_patch_shape = find_a_max_patch_shape(
-            model, model_config["in_channels"], device
-        )
         if input_layout == "YX":
             raw_shape = (1,) + raw.shape
         elif input_layout == "ZYX":
@@ -257,8 +253,13 @@ def unet_prediction(
             raw_shape = raw.shape[1:]
 
         assert len(raw_shape) == 3
-        patch, patch_halo = find_patch_and_halo_shapes(
-            raw_shape, maximum_patch_shape, patch_halo, both_sides=False
+        patch, patch_halo = find_feasible_patch_and_halo_shapes(
+            model,
+            model_config["in_channels"],
+            raw_shape,
+            patch_halo,
+            device,
+            both_sides=False,
         )
 
     logger.info(

--- a/panseg/functionals/prediction/utils/size_finder.py
+++ b/panseg/functionals/prediction/utils/size_finder.py
@@ -19,7 +19,7 @@ def _is_2d_model(model: nn.Module) -> bool:
     return isinstance(model, UNet2D)
 
 
-def find_patch_and_halo_shapes(
+def derive_patch_and_halo_shapes(
     full_volume_shape: tuple[int, int, int],
     max_patch_shape: tuple[int, int, int],
     min_halo_shape: tuple[int, int, int],
@@ -97,7 +97,7 @@ def find_patch_and_halo_shapes(
         return tuple(patch_size), tuple(halo_shape)
 
 
-def find_a_max_patch_shape(
+def probe_max_patch_shape(
     model: nn.Module,
     in_channels: int,
     device: str,
@@ -195,8 +195,8 @@ def find_feasible_patch_and_halo_shapes(
 ) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
     """Recommend a patch shape and halo size that is verified to fit on the device.
 
-    `find_a_max_patch_shape` probes the GPU with isotropic inputs and returns a tight maximum
-    patch shape with no safety margin. `find_patch_and_halo_shapes` then redistributes that
+    `probe_max_patch_shape` probes the GPU with isotropic inputs and returns a tight maximum
+    patch shape with no safety margin. `derive_patch_and_halo_shapes` then redistributes that
     voxel budget to match the aspect ratio of the full volume, so the shape that is actually
     fed to the model at prediction time can require more GPU memory than the probed maximum
     (peak memory does not depend on the voxel count alone), and the amount of free memory can
@@ -227,15 +227,15 @@ def find_feasible_patch_and_halo_shapes(
     Raises:
         RuntimeError: If no feasible patch shape is found within `max_attempts` attempts.
     """
-    max_patch_shape = find_a_max_patch_shape(model, in_channels, device)
+    max_patch_shape = probe_max_patch_shape(model, in_channels, device)
 
     if device == "cpu":
-        return find_patch_and_halo_shapes(
+        return derive_patch_and_halo_shapes(
             full_volume_shape, max_patch_shape, min_halo_shape, both_sides
         )
     patch, halo = (None, None)
     for attempt in range(max_attempts):
-        patch, halo = find_patch_and_halo_shapes(
+        patch, halo = derive_patch_and_halo_shapes(
             full_volume_shape, max_patch_shape, min_halo_shape, both_sides
         )
         if not will_CUDA_OOM(

--- a/panseg/functionals/prediction/utils/size_finder.py
+++ b/panseg/functionals/prediction/utils/size_finder.py
@@ -8,6 +8,10 @@ from panseg.functionals.training.model import UNet2D
 
 logger = logging.getLogger(__name__)
 
+# Voxel-budget multiplier applied to the probed maximum patch shape whenever a derived
+# patch shape fails the batch-size-1 OOM check (see `find_feasible_patch_and_halo_shapes`).
+FEASIBILITY_SHRINK = 0.75
+
 
 def _is_2d_model(model: nn.Module) -> bool:
     if isinstance(model, nn.DataParallel):
@@ -177,6 +181,84 @@ def find_a_max_patch_shape(
         (1, 16 * best_n, 16 * best_n)
         if nn_dim == 2
         else (16 * best_n, 16 * best_n, 16 * best_n)
+    )
+
+
+def find_feasible_patch_and_halo_shapes(
+    model: nn.Module,
+    in_channels: int,
+    full_volume_shape: tuple[int, int, int],
+    min_halo_shape: tuple[int, int, int],
+    device: str,
+    max_attempts: int = 5,
+    both_sides: bool = False,
+) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    """Recommend a patch shape and halo size that is verified to fit on the device.
+
+    `find_a_max_patch_shape` probes the GPU with isotropic inputs and returns a tight maximum
+    patch shape with no safety margin. `find_patch_and_halo_shapes` then redistributes that
+    voxel budget to match the aspect ratio of the full volume, so the shape that is actually
+    fed to the model at prediction time can require more GPU memory than the probed maximum
+    (peak memory does not depend on the voxel count alone), and the amount of free memory can
+    change between probing and prediction. On such machines the batch size determination
+    OOMs even for batch size 1 and prediction aborts (see issue #578).
+
+    To prevent that, the shape derived here is verified with an actual batch-size-1 forward
+    pass via `will_CUDA_OOM`. If it does not fit, the voxel budget of the probed maximum is
+    shrunk by `FEASIBILITY_SHRINK` and the shape is derived and verified again, until a
+    feasible shape is found or `max_attempts` is reached.
+
+    Args:
+        model (nn.Module): The model that will run the prediction.
+        in_channels (int): Number of input channels to the model.
+        full_volume_shape (tuple[int, int, int]): The shape of the full 3D volume (Z, Y, X).
+        min_halo_shape (tuple[int, int, int]): The minimum required halo size per side (Z, Y, X).
+        device (str): The computation device ('cpu', 'cuda', etc.).
+        max_attempts (int, optional): Maximum number of derive-and-verify attempts.
+            Defaults to 5.
+        both_sides (bool, optional): If True, the `min_halo_shape` is applied symmetrically
+            on both sides of the patch. Defaults to False.
+
+    Returns:
+        tuple[tuple[int, int, int], tuple[int, int, int]]:
+            - Verified patch shape `(Z, Y, X)`.
+            - Halo size on one side `(Z, Y, X)`.
+
+    Raises:
+        RuntimeError: If no feasible patch shape is found within `max_attempts` attempts.
+    """
+    max_patch_shape = find_a_max_patch_shape(model, in_channels, device)
+
+    if device == "cpu":
+        return find_patch_and_halo_shapes(
+            full_volume_shape, max_patch_shape, min_halo_shape, both_sides
+        )
+    patch, halo = (None, None)
+    for attempt in range(max_attempts):
+        patch, halo = find_patch_and_halo_shapes(
+            full_volume_shape, max_patch_shape, min_halo_shape, both_sides
+        )
+        if not will_CUDA_OOM(
+            model, in_channels, patch, halo, batch_size=1, device=device
+        ):
+            if attempt > 0:
+                logger.info(
+                    f"Using reduced patch shape {patch} and halo {halo} after "
+                    f"{attempt} shrink(s) of the maximum patch shape."
+                )
+            return patch, halo
+        logger.warning(
+            f"Auto-determined patch shape {patch} with halo {halo} does not fit on "
+            f"{device}; retrying with a {1 - FEASIBILITY_SHRINK:.0%} smaller voxel budget."
+        )
+        max_patch_shape = tuple(
+            max(1, int(dim * FEASIBILITY_SHRINK ** (1 / 3))) for dim in max_patch_shape
+        )
+
+    raise RuntimeError(
+        f"Could not determine a feasible patch shape on {device} after {max_attempts} "
+        f"attempts (last tried patch shape {patch} with halo {halo}). "
+        "Please reduce the patch size manually or free up GPU memory."
     )
 
 

--- a/tests/functionals/prediction/test_size_finder.py
+++ b/tests/functionals/prediction/test_size_finder.py
@@ -8,10 +8,10 @@ from torch import nn
 from panseg.core.zoo import model_zoo
 from panseg.functionals.prediction.utils import size_finder
 from panseg.functionals.prediction.utils.size_finder import (
-    find_a_max_patch_shape,
+    derive_patch_and_halo_shapes,
     find_batch_size,
     find_feasible_patch_and_halo_shapes,
-    find_patch_and_halo_shapes,
+    probe_max_patch_shape,
     will_CUDA_OOM,
 )
 
@@ -108,10 +108,10 @@ PROBED_MAX = (256, 256, 256)
         ((12, 12, 8), (10, 10, 10), (4, 4, 4), ((3, 3, 8), (4, 4, 0))),
     ],
 )
-def test_find_patch_and_halo_shapes(
+def test_derive_patch_and_halo_shapes(
     full_volume_shape, max_patch_shape, min_halo_shape, expected
 ):
-    result = find_patch_and_halo_shapes(
+    result = derive_patch_and_halo_shapes(
         full_volume_shape, max_patch_shape, min_halo_shape
     )
     assert result == expected
@@ -124,7 +124,7 @@ def test_find_patch_and_halo_shapes(
         min_halo_shape[1] * 2,
         min_halo_shape[2] * 2,
     )
-    result = find_patch_and_halo_shapes(
+    result = derive_patch_and_halo_shapes(
         full_volume_shape, max_patch_shape, double_halo_shape, both_sides=True
     )
     assert result == expected
@@ -152,14 +152,14 @@ def fake_oom_probe(monkeypatch):
     monkeypatch.setattr(size_finder, "will_CUDA_OOM", probe)
     monkeypatch.setattr(
         size_finder,
-        "find_a_max_patch_shape",
+        "probe_max_patch_shape",
         lambda model, in_channels, device: PROBED_MAX,
     )
     return probe
 
 
-def test_find_patch_and_halo_shapes_feasibility_loop_drives_oom_probe(fake_oom_probe):
-    expected = find_patch_and_halo_shapes(VOL, PROBED_MAX, HALO)
+def test_find_feasible_patch_and_halo_shapes_drives_oom_probe(fake_oom_probe):
+    expected = derive_patch_and_halo_shapes(VOL, PROBED_MAX, HALO)
     result = find_feasible_patch_and_halo_shapes(
         nn.Module(), 1, VOL, HALO, device="cuda"
     )
@@ -167,7 +167,7 @@ def test_find_patch_and_halo_shapes_feasibility_loop_drives_oom_probe(fake_oom_p
     assert len(fake_oom_probe.verified_shapes) == 1
 
 
-def test_find_patch_and_halo_shapes_feasibility_loop_shrinks_until_verified(
+def test_find_feasible_patch_and_halo_shapes_shrinks_until_verified(
     fake_oom_probe,
 ):
     fake_oom_probe.threshold = (
@@ -184,7 +184,7 @@ def test_find_patch_and_halo_shapes_feasibility_loop_shrinks_until_verified(
     assert len(fake_oom_probe.verified_shapes) == 2
 
 
-def test_find_patch_and_halo_shapes_feasibility_loop_raises_when_nothing_fits(
+def test_find_feasible_patch_and_halo_shapes_raises_when_nothing_fits(
     fake_oom_probe,
 ):
     fake_oom_probe.threshold = 1  # every attempt OOMs
@@ -198,14 +198,14 @@ def test_find_patch_and_halo_shapes_feasibility_loop_raises_when_nothing_fits(
     assert len(fake_oom_probe.verified_shapes) == 3
 
 
-def test_find_patch_and_halo_shapes_feasibility_loop_skips_verification_on_cpu(
+def test_find_feasible_patch_and_halo_shapes_skips_verification_on_cpu(
     fake_oom_probe,
 ):
     result = find_feasible_patch_and_halo_shapes(
         nn.Module(), 1, VOL, HALO, device="cpu"
     )
 
-    assert result == find_patch_and_halo_shapes(VOL, PROBED_MAX, HALO)
+    assert result == derive_patch_and_halo_shapes(VOL, PROBED_MAX, HALO)
     assert fake_oom_probe.verified_shapes == []
 
 
@@ -216,7 +216,7 @@ def test_find_patch_and_halo_shapes_feasibility_loop_skips_verification_on_cpu(
 @pytest.mark.parametrize("model_name", MAX_PATCH_SHAPES.keys())
 def test_find_patch_shape(model_name):
     model, _, _ = model_zoo.get_model_by_name(model_name, model_update=DOWNLOAD_MODELS)
-    found_patch_shape = find_a_max_patch_shape(model, 1, "cuda:0")
+    found_patch_shape = probe_max_patch_shape(model, 1, "cuda:0")
     expected_patch_shape = MAX_PATCH_SHAPES[model_name][GPU_DEVICE_NAME]
     assert found_patch_shape == expected_patch_shape
 
@@ -241,7 +241,7 @@ def test_find_patch_shape_error_handling():
     model, _, _ = model_zoo.get_model_by_name(
         "PanSeg_3Dnuc_platinum", model_update=DOWNLOAD_MODELS
     )
-    found_patch_shape = find_a_max_patch_shape(model, 1, "cuda:0")
+    found_patch_shape = probe_max_patch_shape(model, 1, "cuda:0")
     if "NVIDIA A100-PCIE-40GB" == GPU_DEVICE_NAME:
         print("NVIDIA A100-PCIE-40GB tested")
         assert found_patch_shape == (352, 352, 352)
@@ -269,11 +269,11 @@ def test_find_feasible_patch_and_halo_shapes_shrinks_on_oom(monkeypatch):
     free, total = torch.cuda.mem_get_info()
     if free < 3 * 2**30:  # not enough spare VRAM to simulate competing allocations
         pytest.skip("Less than 3 GiB of free VRAM available.")
-    reference = find_patch_and_halo_shapes(
-        full_volume_shape, find_a_max_patch_shape(model, 1, device), min_halo_shape
+    reference = derive_patch_and_halo_shapes(
+        full_volume_shape, probe_max_patch_shape(model, 1, device), min_halo_shape
     )
 
-    real_find = size_finder.find_patch_and_halo_shapes
+    real_find = size_finder.derive_patch_and_halo_shapes
     holder = []
 
     def reserving_find(*args, **kwargs):
@@ -283,7 +283,7 @@ def test_find_feasible_patch_and_halo_shapes_shrinks_on_oom(monkeypatch):
             )
         return real_find(*args, **kwargs)
 
-    monkeypatch.setattr(size_finder, "find_patch_and_halo_shapes", reserving_find)
+    monkeypatch.setattr(size_finder, "derive_patch_and_halo_shapes", reserving_find)
     try:
         patch, patch_halo = find_feasible_patch_and_halo_shapes(
             model, 1, full_volume_shape, min_halo_shape, device

--- a/tests/functionals/prediction/test_size_finder.py
+++ b/tests/functionals/prediction/test_size_finder.py
@@ -3,12 +3,16 @@ import os
 import numpy as np
 import pytest
 import torch
+from torch import nn
 
 from panseg.core.zoo import model_zoo
+from panseg.functionals.prediction.utils import size_finder
 from panseg.functionals.prediction.utils.size_finder import (
     find_a_max_patch_shape,
     find_batch_size,
+    find_feasible_patch_and_halo_shapes,
     find_patch_and_halo_shapes,
+    will_CUDA_OOM,
 )
 
 IN_GITHUB_ACTIONS = (
@@ -27,6 +31,7 @@ ALL_TESTED_GPUS = [
     "NVIDIA A100-PCIE-40GB",
     "NVIDIA A40",
     "NVIDIA GeForce RTX 4050 Laptop GPU",
+    "NVIDIA GeForce RTX 4090",
 ]
 MAX_PATCH_SHAPES = {
     "generic_confocal_3D_unet": {
@@ -35,6 +40,7 @@ MAX_PATCH_SHAPES = {
         "NVIDIA A100-PCIE-40GB": (272, 272, 272),
         "NVIDIA A40": (272, 272, 272),
         "NVIDIA GeForce RTX 4050 Laptop GPU": (160, 160, 160),
+        "NVIDIA GeForce RTX 4090": (256, 256, 256),
     },
     "confocal_2D_unet_ovules_ds2x": {
         "NVIDIA GeForce RTX 2080 Ti": (
@@ -50,6 +56,7 @@ MAX_PATCH_SHAPES = {
         "NVIDIA A100-PCIE-40GB": (1, 3200, 3200),
         "NVIDIA A40": (1, 3200, 3200),
         "NVIDIA GeForce RTX 4050 Laptop GPU": (1, 1280, 1280),
+        "NVIDIA GeForce RTX 4090": (1, 2560, 2560),
     },
 }
 
@@ -58,6 +65,11 @@ try:
     GPU_DEVICE_NAME = torch.cuda.get_device_name(0) if not IN_GITHUB_ACTIONS else ""
 except AssertionError:  # catch Pytorch not installed with CUDA support
     GPU_DEVICE_NAME = ""
+
+# Fixed scenario for the feasibility-loop unit tests (no GPU required, will_CUDA_OOM is faked)
+VOL = (48, 1536, 1536)
+HALO = (0, 44, 44)
+PROBED_MAX = (256, 256, 256)
 
 
 @pytest.mark.parametrize(
@@ -118,6 +130,85 @@ def test_find_patch_and_halo_shapes(
     assert result == expected
 
 
+class FakeOomProbe:
+    """Stand-in for will_CUDA_OOM: OOMs iff the actual forward shape exceeds `threshold` voxels."""
+
+    def __init__(self):
+        self.threshold = None  # None -> never OOM
+        self.verified_shapes = []
+
+    def __call__(self, model, in_channels, patch_shape, patch_halo, batch_size, device):
+        actual = tuple(patch_shape[i] + 2 * patch_halo[i] for i in range(3))
+        self.verified_shapes.append(actual)
+        if self.threshold is None:
+            return False
+        return int(np.prod(actual)) > self.threshold
+
+
+@pytest.fixture()
+def fake_oom_probe(monkeypatch):
+    """Deterministic stand-ins for the GPU-probing pieces of the feasibility loop."""
+    probe = FakeOomProbe()
+    monkeypatch.setattr(size_finder, "will_CUDA_OOM", probe)
+    monkeypatch.setattr(
+        size_finder,
+        "find_a_max_patch_shape",
+        lambda model, in_channels, device: PROBED_MAX,
+    )
+    return probe
+
+
+def test_find_patch_and_halo_shapes_feasibility_loop_drives_oom_probe(fake_oom_probe):
+    expected = find_patch_and_halo_shapes(VOL, PROBED_MAX, HALO)
+    result = find_feasible_patch_and_halo_shapes(
+        nn.Module(), 1, VOL, HALO, device="cuda"
+    )
+    assert result == expected
+    assert len(fake_oom_probe.verified_shapes) == 1
+
+
+def test_find_patch_and_halo_shapes_feasibility_loop_shrinks_until_verified(
+    fake_oom_probe,
+):
+    fake_oom_probe.threshold = (
+        15_000_000  # first attempt (16.8M voxels) OOMs, the shrunken one fits
+    )
+
+    result = find_feasible_patch_and_halo_shapes(
+        nn.Module(), 1, VOL, HALO, device="cuda"
+    )
+
+    result_voxels = int(np.prod([result[0][i] + 2 * result[1][i] for i in range(3)]))
+    assert result_voxels <= fake_oom_probe.threshold
+    assert result_voxels < int(np.prod(fake_oom_probe.verified_shapes[0]))
+    assert len(fake_oom_probe.verified_shapes) == 2
+
+
+def test_find_patch_and_halo_shapes_feasibility_loop_raises_when_nothing_fits(
+    fake_oom_probe,
+):
+    fake_oom_probe.threshold = 1  # every attempt OOMs
+
+    with pytest.raises(
+        RuntimeError, match="Could not determine a feasible patch shape"
+    ):
+        find_feasible_patch_and_halo_shapes(
+            nn.Module(), 1, VOL, HALO, device="cuda", max_attempts=3
+        )
+    assert len(fake_oom_probe.verified_shapes) == 3
+
+
+def test_find_patch_and_halo_shapes_feasibility_loop_skips_verification_on_cpu(
+    fake_oom_probe,
+):
+    result = find_feasible_patch_and_halo_shapes(
+        nn.Module(), 1, VOL, HALO, device="cpu"
+    )
+
+    assert result == find_patch_and_halo_shapes(VOL, PROBED_MAX, HALO)
+    assert fake_oom_probe.verified_shapes == []
+
+
 @pytest.mark.skipif(
     GPU_DEVICE_NAME not in ALL_TESTED_GPUS,
     reason="Measured devices are not available.",
@@ -157,3 +248,51 @@ def test_find_patch_shape_error_handling():
     if "NVIDIA A40" == GPU_DEVICE_NAME:
         print("NVIDIA A40 tested")
         assert found_patch_shape == (352, 352, 352)
+
+
+@pytest.mark.skipif(
+    IN_GITHUB_ACTIONS or GPU_DEVICE_NAME == "",
+    reason="CUDA device not available.",
+)
+def test_find_feasible_patch_and_halo_shapes_shrinks_on_oom(monkeypatch):
+    """Regression for issue #578: when GPU memory becomes unavailable between the
+    max-patch probe and the batch size determination (e.g. other processes on a shared
+    GPU), the auto-determined patch shape must shrink until it fits instead of raising
+    an OOM error at batch size 1."""
+    model, _, _ = model_zoo.get_model_by_name(
+        "confocal_3D_unet_ovules_ds3x", model_update=DOWNLOAD_MODELS
+    )
+    device = "cuda:0"
+    full_volume_shape = (48, 1536, 1536)
+    min_halo_shape = model_zoo.compute_3D_halo_for_pytorch3dunet(model)
+
+    free, total = torch.cuda.mem_get_info()
+    if free < 3 * 2**30:  # not enough spare VRAM to simulate competing allocations
+        pytest.skip("Less than 3 GiB of free VRAM available.")
+    reference = find_patch_and_halo_shapes(
+        full_volume_shape, find_a_max_patch_shape(model, 1, device), min_halo_shape
+    )
+
+    real_find = size_finder.find_patch_and_halo_shapes
+    holder = []
+
+    def reserving_find(*args, **kwargs):
+        if not holder:  # emulate memory appearing after the max-patch probe
+            holder.append(
+                torch.empty(max(total // 10, 2**30), dtype=torch.uint8, device=device)
+            )
+        return real_find(*args, **kwargs)
+
+    monkeypatch.setattr(size_finder, "find_patch_and_halo_shapes", reserving_find)
+    try:
+        patch, patch_halo = find_feasible_patch_and_halo_shapes(
+            model, 1, full_volume_shape, min_halo_shape, device
+        )
+    finally:
+        holder.clear()
+        torch.cuda.empty_cache()
+
+    # the returned shape is verified to fit even with the competing allocation in place
+    assert not will_CUDA_OOM(model, 1, patch, patch_halo, 1, device)
+    # and the shrink loop actually engaged (the unshrunken shape no longer fit)
+    assert int(np.prod(patch)) < int(np.prod(reference[0]))


### PR DESCRIPTION
Fixes #578

## Problem

Automatic patch-shape determination, prediction aborts on some machines with
`Could not determine a feasible batch size ...` (OOM at batch size 1) 

## Fix

New `find_feasible_patch_and_halo_shapes`, used by `unet_prediction`'s auto path:

1. probe the max patch shape (unchanged `find_a_max_patch_shape`),
2. derive patch + halo (unchanged `find_patch_and_halo_shapes`),
3. NEW: verify with a real batch-size-1 forward pass (`will_CUDA_OOM`),
4. on OOM, shrink the voxel budget by `FEASIBILITY_SHRINK = 0.75` and re-derive/verify
   (max 5 attempts); if nothing fits, raise an informative `RuntimeError`.