### PR TITLE
fix: resilient model downloads from zenodo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,21 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.2
 
+      # Cache the PanSeg model directory across runs. The key is the git blob
+      # hash of the official zoo config: the downloaded files are a pure
+      # function of the URLs declared there, so a PR that does not touch it
+      # reuses the cached models and makes no Zenodo request.
+      - name: Compute model zoo cache key
+        id: model-zoo-key
+        run: |
+          echo "hash=$(git rev-parse HEAD:panseg/resources/models_zoo.yaml)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache PanSeg models
+        uses: actions/cache@v4
+        with:
+          path: ~/.panseg_models
+          key: panseg-models-${{ steps.model-zoo-key.outputs.hash }}
+
       - name: Setup Qt headless display
         uses: pyvista/setup-headless-display-action@v4.3
         with:

--- a/panseg/core/zoo.py
+++ b/panseg/core/zoo.py
@@ -319,7 +319,12 @@ class ModelZoo:
     def check_models(
         self, model_name: str, update_files: bool = False, config_only: bool = False
     ) -> None:
-        """Check and download model files and configurations as needed."""
+        """Check and download model files and configurations as needed.
+
+        After the download step, verifies that the expected files are on disk
+        and raises a FileNotFoundError naming the model (and its zoo URL when
+        it has one) if anything is missing.
+        """
         model_dir = PATH_PANSEG_MODELS / model_name
         model_dir.mkdir(parents=True, exist_ok=True)
 
@@ -327,25 +332,39 @@ class ModelZoo:
             f"check_models, model_name: {model_name}, "
             f"update_files {update_files}, config_only {config_only}"
         )
-        # Check if the model exists and download it if it doesn't
-        loaded = all(
-            [
-                (model_dir / FILE_CONFIG_TRAIN_YAML).exists(),
-                (model_dir / FILE_BEST_MODEL_PYTORCH).exists(),
-            ]
-        )
-        if (not loaded) or update_files:
-            model_file = PATH_MODEL_ZOO
-            config = load_config(model_file)
 
+        expected_files = [FILE_CONFIG_TRAIN_YAML]
+        if not config_only:
+            expected_files.append(FILE_BEST_MODEL_PYTORCH)
+
+        model_url = None
+        downloaded = False
+        missing = [f for f in expected_files if not (model_dir / f).exists()]
+        if missing or update_files:
+            config = load_config(PATH_MODEL_ZOO)
             model_url = config.get(model_name, {}).get("model_url")
             if model_url:
                 self._download_model_files(model_url, model_dir, config_only)
-                logger_zoo.info(f"Download finished for {model_name}")
+                downloaded = True
             else:
                 logger_zoo.warning(
                     f"Model {model_name} not found in the models zoo configuration."
                 )
+            missing = [f for f in expected_files if not (model_dir / f).exists()]
+
+        if missing:
+            raise FileNotFoundError(
+                f"Model '{model_name}' has missing files after the download step: "
+                f"{', '.join(missing)} (expected in {model_dir}). "
+                + (
+                    f"Model URL: {model_url}"
+                    if model_url is not None
+                    else "The model was not found in the models zoo configuration."
+                )
+            )
+
+        if downloaded:
+            logger_zoo.info(f"Download finished for {model_name}")
 
     def _get_model_config_path_by_name(self, model_name: str) -> Path:
         """Return the path to the training configuration for a model in zoo."""

--- a/panseg/utils.py
+++ b/panseg/utils.py
@@ -1,9 +1,13 @@
 import importlib
 import logging
+import os
 import re
+import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from shutil import rmtree
+from typing import Optional
 
 import requests
 import yaml
@@ -12,6 +16,11 @@ from packaging.version import Version
 from panseg import PATH_PANSEG_MODELS
 
 logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = (10, 60)
+MAX_DOWNLOAD_ATTEMPTS = 5
+INITIAL_RETRY_DELAY = 10
+MAX_RETRY_DELAY = 30
 
 
 def load_config(config_path: Path) -> dict:
@@ -29,23 +38,55 @@ def save_config(config: dict, config_path: Path) -> None:
 
 
 def download_file(url: str, filename: Path) -> None:
-    """Download a single file from a URL to a specified filename."""
+    """Download a single file from a URL to a specified filename.
+
+    Each request uses an explicit (connect, read) timeout, and failed requests
+    are retried with exponential backoff (delays ramping up to
+    MAX_RETRY_DELAY). The file is streamed to a temporary file in the target
+    directory and atomically renamed on success, so an interrupted download
+    can never leave a partial file at the final path. If all attempts fail, a
+    requests.RequestException naming the URL and the underlying error is raised.
+    """
     headers = {
         "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0",
         "Accept-Language": "en-US,en;q=0.9",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     }
-    try:
-        # Use stream for large files
-        response = requests.get(url, stream=True, headers=headers)
-        response.raise_for_status()
-        with open(filename, "wb") as f:
-            for chunk in response.iter_content(
-                chunk_size=8192
-            ):  # Adjust chunk size as needed
-                f.write(chunk)
-    except requests.RequestException as e:
-        logger.warning(f"Failed to download {url}. Error: {e}")
+    filename = Path(filename)
+    delay = INITIAL_RETRY_DELAY
+    last_error: Optional[requests.RequestException] = None
+    for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+        try:
+            response = requests.get(
+                url, stream=True, headers=headers, timeout=REQUEST_TIMEOUT
+            )
+            response.raise_for_status()
+            fd, tmp_path = tempfile.mkstemp(
+                dir=str(filename.parent), prefix=f".{filename.name}."
+            )
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                os.replace(tmp_path, filename)
+            except Exception:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+                raise
+            return
+        except requests.RequestException as e:
+            last_error = e
+            logger.warning(
+                f"Failed to download {url} "
+                f"(attempt {attempt}/{MAX_DOWNLOAD_ATTEMPTS}): {e}"
+            )
+            if attempt < MAX_DOWNLOAD_ATTEMPTS:
+                time.sleep(delay)
+                delay = min(MAX_RETRY_DELAY, 2 * delay)
+
+    raise requests.RequestException(
+        f"Failed to download {url} after {MAX_DOWNLOAD_ATTEMPTS} attempts: {last_error}"
+    ) from last_error
 
 
 def download_files(urls: dict, out_dir: Path) -> None:

--- a/tests/core/test_zoo.py
+++ b/tests/core/test_zoo.py
@@ -1,8 +1,12 @@
+import logging
 import os
+from pathlib import Path
 
 import pytest
 import torch
 
+import panseg.core.zoo as zoo_module
+from panseg import FILE_BEST_MODEL_PYTORCH, FILE_CONFIG_TRAIN_YAML
 from panseg.core.zoo import model_zoo
 from panseg.functionals.training.model import UNet2D
 from tests.conftest import IS_CUDA_AVAILABLE
@@ -72,3 +76,71 @@ class TestBioImageIOModelZoo:
         model, _, _ = model_zoo.get_model_by_id(model_id)
         halo = model_zoo.compute_halo(model)
         assert halo == 44
+
+
+ZOO_MODEL_NAME = "confocal_2D_unet_ovules_ds2x"
+ZOO_MODEL_URL = (
+    "https://zenodo.org/record/7772709/files/confocal_2D_unet_ovules_ds2x.pytorch"
+)
+
+
+class TestCheckModelsVerification:
+    """check_models must verify files on disk and fail loudly when missing."""
+
+    def test_files_present_no_download_attempted(self, mocker, monkeypatch, tmp_path):
+        model_dir = tmp_path / "generic_confocal_3D_unet"
+        model_dir.mkdir()
+        (model_dir / FILE_CONFIG_TRAIN_YAML).write_text("model: {}")
+        (model_dir / FILE_BEST_MODEL_PYTORCH).write_bytes(b"weights")
+        monkeypatch.setattr(zoo_module, "PATH_PANSEG_MODELS", tmp_path)
+        spy = mocker.patch.object(model_zoo, "_download_model_files")
+
+        model_zoo.check_models("generic_confocal_3D_unet")
+
+        spy.assert_not_called()
+
+    def test_download_succeeds_verified_and_logged(
+        self, mocker, monkeypatch, tmp_path, caplog
+    ):
+        monkeypatch.setattr(zoo_module, "PATH_PANSEG_MODELS", tmp_path)
+
+        def fake_download(model_url, out_dir, config_only=False):
+            model_dir = Path(out_dir)
+            (model_dir / FILE_CONFIG_TRAIN_YAML).write_text("model: {}")
+            if not config_only:
+                (model_dir / FILE_BEST_MODEL_PYTORCH).write_bytes(b"weights")
+
+        mocker.patch.object(
+            model_zoo, "_download_model_files", side_effect=fake_download
+        )
+
+        with caplog.at_level(logging.INFO, logger="panseg.core.zoo"):
+            model_zoo.check_models(ZOO_MODEL_NAME)
+
+        assert f"Download finished for {ZOO_MODEL_NAME}" in caplog.text
+
+    def test_download_leaves_files_missing_raises_with_name_and_url(
+        self, mocker, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(zoo_module, "PATH_PANSEG_MODELS", tmp_path)
+        # no-op downloader: simulates a download that failed silently
+        mocker.patch.object(model_zoo, "_download_model_files")
+
+        with pytest.raises(FileNotFoundError) as excinfo:
+            model_zoo.check_models(ZOO_MODEL_NAME)
+
+        message = str(excinfo.value)
+        assert ZOO_MODEL_NAME in message
+        assert ZOO_MODEL_URL in message
+
+    def test_config_only_skip_when_config_present(self, mocker, monkeypatch, tmp_path):
+        model_dir = tmp_path / "generic_confocal_3D_unet"
+        model_dir.mkdir()
+        (model_dir / FILE_CONFIG_TRAIN_YAML).write_text("model: {}")
+        monkeypatch.setattr(zoo_module, "PATH_PANSEG_MODELS", tmp_path)
+        spy = mocker.patch.object(model_zoo, "_download_model_files")
+
+        # only the config was requested and it is present: no download
+        model_zoo.check_models("generic_confocal_3D_unet", config_only=True)
+
+        spy.assert_not_called()

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,7 +1,10 @@
+from unittest.mock import MagicMock
+
 import pytest
 import requests
 
-from panseg.utils import check_version
+import panseg.utils as utils_mod
+from panseg.utils import check_version, download_file
 
 
 @pytest.fixture
@@ -197,3 +200,77 @@ def test_check_version_value_error(mock_logger, requests_mock):
     mock_logger.warning.assert_called_once_with(
         "Could not parse version information. Error: Invalid version: 'invalid_version'"
     )
+
+
+def _ok_response(payload=b"fake-bytes"):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.iter_content.side_effect = lambda chunk_size=None: iter([payload])
+    return resp
+
+
+class TestDownloadFileResilience:
+    """download_file must be timeout-bound, retried, atomic and loud."""
+
+    def test_success_first_attempt_writes_file(self, tmp_path, mocker):
+        url = "https://zenodo.org/record/1/files/a.pytorch"
+        target = tmp_path / "a.pytorch"
+        mock_get = mocker.patch.object(
+            utils_mod.requests, "get", return_value=_ok_response(b"weights")
+        )
+
+        download_file(url, target)
+
+        assert target.read_bytes() == b"weights"
+        # every request must carry an explicit (connect, read) timeout
+        for call in mock_get.call_args_list:
+            timeout = call.kwargs.get("timeout")
+            assert timeout is not None, "request was made without a timeout"
+
+    def test_transient_failure_then_retry_succeeds(self, tmp_path, mocker):
+        url = "https://zenodo.org/record/1/files/a.pytorch"
+        target = tmp_path / "a.pytorch"
+        mock_get = mocker.patch.object(
+            utils_mod.requests,
+            "get",
+            side_effect=[
+                requests.exceptions.HTTPError("504 Gateway Timeout"),
+                _ok_response(b"weights"),
+            ],
+        )
+        mock_sleep = mocker.patch.object(utils_mod.time, "sleep")
+
+        download_file(url, target)
+
+        assert target.read_bytes() == b"weights"
+        assert mock_get.call_count == 2
+        # exponential backoff starts at the initial delay (seconds scale)
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [
+            utils_mod.INITIAL_RETRY_DELAY
+        ]
+
+    def test_all_attempts_fail_raises_and_leaves_no_residue(self, tmp_path, mocker):
+        url = "https://zenodo.org/record/1/files/a.pytorch"
+        target = tmp_path / "a.pytorch"
+        mock_get = mocker.patch.object(
+            utils_mod.requests,
+            "get",
+            side_effect=requests.exceptions.ConnectionError("connection reset"),
+        )
+        mock_sleep = mocker.patch.object(utils_mod.time, "sleep")
+        mock_logger = mocker.patch.object(utils_mod, "logger")
+
+        with pytest.raises(requests.RequestException) as excinfo:
+            download_file(url, target)
+
+        message = str(excinfo.value)
+        assert url in message
+        assert "connection reset" in message  # underlying cause is named
+        assert mock_get.call_count == utils_mod.MAX_DOWNLOAD_ATTEMPTS
+        # exponential backoff ramps from seconds up to ~30s across attempts
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [10, 20, 30, 30]
+        # each failed attempt is logged as a warning
+        assert mock_logger.warning.call_count == utils_mod.MAX_DOWNLOAD_ATTEMPTS
+        # neither the final file nor any temp-file residue remains
+        assert not target.exists()
+        assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
Fixes #591

Sometimes model downloads from zenodo returned 504, which lead to failing CI.

This PR makes zoo model downloads more robust, and makes any real failure loud and self-explanatory.
It also stops CI from re-downloading the official models on every PR by caching them.